### PR TITLE
Under certain conditions connections to the database would not be sto…

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var RETRY_TIMEOUT = 4000;
 function zongjiManager(dsn, options, onBinlog) {
   var newInst = new ZongJi(dsn, options);
     newInst.on('error', function(reason) {
+        //Make sure all database connections are cancelled before creating a new one
+        newInst.stop();
+
         newInst.removeListener('binlog', onBinlog);
     	  newInst.child = false;
         setTimeout(function() {


### PR DESCRIPTION
ZongJi opens two connections to the MySQL database, one for the binlog events, another one for getting schema and to kill the binlog connection. Under certain conditions it can happen, that the control connection is not stopped. But as mysql-events tries to reconnect in the error handler it produces a new connection to the MySQL server every 4 seconds. In our case we quickly reached the connection limit and all other applications stopped working as their connection attempt got rejected.

When we started to test mysql-events we saw this curve while running our Node-JS application:
<img width="784" alt="bildschirmfoto 2017-05-12 um 13 49 31" src="https://cloud.githubusercontent.com/assets/953401/25996918/f81419f0-3719-11e7-9b05-e4c1554fcb9f.png">

As you can see the application started to add connections until it reached the max connection limit of our MySQL database. As we reached that every other application got rejected and rendered our database server useless.

This happend after we received these log outputs:

`ZongJi error event { [Error: Connection lost: The server closed the connection.] fatal: true, code: 'PROTOCOL_CONNECTION_LOST' }
ZongJi error event { [Error: ER_MASTER_FATAL_ERROR_READING_BINLOG: A slave with the same server_uuid/server_id as this slave has connected to the master; the first event 'mysql-bin.000002' at 95042611, the last event read from '/var/log/mysql/mysql-bin.000002' at 280937716, the last byte read from '/var/log/mysql/mysql-bin.000002' at 280937716.]
  code: 'ER_MASTER_FATAL_ERROR_READING_BINLOG',
  errno: 1236,
  sqlState: 'HY000' }
ZongJi error event { [Error: Connection lost: The server closed the connection.] fatal: true, code: 'PROTOCOL_CONNECTION_LOST' }`

Something happend and caused an error. From this point on we saw the connections start raising. Then a few hours later we saw this:

`EventEmitter.prototype.emit = function emit(type) {
RangeError: Maximum call stack size exceeded
    at ZongJi.emit (events.js:117:44)
    at ZongJi.<anonymous> (/var/www/server/appserver/node_modules/mysql-events/index.js:20:68)
    at emitOne (events.js:77:13)
    at ZongJi.emit (events.js:169:7)
    at ZongJi.<anonymous> (/var/www/server/appserver/node_modules/mysql-events/index.js:20:68)
    at emitOne (events.js:77:13)
    at ZongJi.emit (events.js:169:7)
    at ZongJi.<anonymous> (/var/www/server/appserver/node_modules/mysql-events/index.js:20:68)
    at emitOne (events.js:77:13)
    at ZongJi.emit (events.js:169:7)`

We were able to reproduce this issue by running one instance of our mysql-events based app and starting another one with the same id.

This may be a special case and you should always make sure to not run the same client with the same serverId, but who knows which rare cases can happen during production so it makes sense to fix it.

Changing the code as promoted in this pull requests fixes the issue as this makes sure that all connections to the MySQL-Database are cancelled.